### PR TITLE
Fix bug when retrieving notes

### DIFF
--- a/LbhNCCApi/Actions/UHActions.cs
+++ b/LbhNCCApi/Actions/UHActions.cs
@@ -139,12 +139,12 @@ namespace LbhNCCApi.Actions
             var result = uhtconn.ExecuteScalar<object>(
                 $@"select tenagree_sid from tenagree where tag_ref = '{tenancyAgreementRef}' "
                     );
-            string tenagree_sid = result.ToString();
             uhtconn.Close();
 
             var nccList = new List<dynamic>();
-            if (!string.IsNullOrEmpty(tenagree_sid))
+            if (result != null)
             {
+                string tenagree_sid = result.ToString();
                 ///and SecureCategory <> '002' and NoteType <> '002'   this was added to avoid any Notes which we have added as our ones should come via CRM
                 SqlConnection uhwconn = new SqlConnection(_uhwconnstring);
                 uhwconn.Open();

--- a/LbhNCCApi/Controllers/ParisController.cs
+++ b/LbhNCCApi/Controllers/ParisController.cs
@@ -21,7 +21,8 @@ namespace LbhNCCApi.Controllers
         {
             try
             {
-                return Json(await ParisActions.MakeParisCall(parisparam));
+                //return Json(await ParisActions.MakeParisCall(parisparam));
+                return Ok();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The application was crashing when retrieving notes through the GetAllActionDiaryAndNotes endpoint. when the id for notes (tenagree_sid) was not found in the db.
I've also done a minor change in the paris controller as it was preventing the application to build. This controller is not in use and will be completely removed in a future refactoring.
