### PR TITLE
Post contact details to the API when setting new communcation details

### DIFF
--- a/LbhNCCApi/Actions/CRMActions.cs
+++ b/LbhNCCApi/Actions/CRMActions.cs
@@ -763,14 +763,22 @@ namespace LbhNCCApi.Actions
             return null;
         }
 
-        public async Task<object> SetCitizenCommunication(string contactid, string CommsDetail, HttpClient _client)
+        public async Task<object> SetCitizenCommunication(string contactId, string commsDetail, HttpClient _client,
+            HttpClient contactDetailsClient)
         {
+            var contactDetailsApi = new ContactDetailsApi(contactDetailsClient);
             try
             {
-                var query = CRMAPICall.UpdateContactComms(contactid);
+                var query = CRMAPICall.UpdateContactComms(contactId);
                 JObject comms = new JObject();
-                comms.Add("hackney_communicationdetails", CommsDetail);
-                return  await CRMAPICall.UpdateObject(_client, query, comms);
+                comms.Add("hackney_communicationdetails", commsDetail);
+                var crmResponse = await CRMAPICall.UpdateObject(_client, query, comms);
+                if (Convert.ToBoolean(crmResponse["response"]["success"]))
+                {
+                    await contactDetailsApi.PostContactDetails(contactId, commsDetail).ConfigureAwait(true);
+                }
+
+                return crmResponse;
             }
             catch (Exception ex)
             {

--- a/LbhNCCApi/Actions/ContactDetailsApi.cs
+++ b/LbhNCCApi/Actions/ContactDetailsApi.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using LbhNCCApi.Interfaces;
+using Newtonsoft.Json;
+
+namespace LbhNCCApi.Actions
+{
+    public class ContactDetailsApi : IContactDetailsApi
+    {
+        private readonly HttpClient _httpClient;
+
+        public ContactDetailsApi(HttpClient httpClient)
+        {
+
+            _httpClient = httpClient;
+        }
+
+        public async Task PostContactDetails(string contactId, string commsDetail)
+        {
+            var deserializedDetails = JsonConvert.DeserializeObject<CommunicationDetails>(commsDetail);
+            var telephones = deserializedDetails.telephone.Select(t => new ContactDetailsPostRequest
+            {
+                Active = true,
+                Default = deserializedDetails.Default.telephone == t,
+                Value = t,
+                TypeId = 1,
+                NccContactId = contactId
+            });
+            var mobiles = deserializedDetails.mobile.Select(m => new ContactDetailsPostRequest
+            {
+                Active = true,
+                Default = deserializedDetails.Default.mobile == m,
+                Value = m,
+                TypeId = 3,
+                NccContactId = contactId
+            });
+            var emails = deserializedDetails.email.Select(e => new ContactDetailsPostRequest
+            {
+                Active = true,
+                Default = deserializedDetails.Default.email == e,
+                Value = e,
+                TypeId = 2,
+                NccContactId = contactId
+            });
+            var allContacts = telephones.Concat(mobiles).Concat(emails);
+            foreach (var contact in allContacts)
+            {
+                var jsonRequestBody = JsonConvert.SerializeObject(contact);
+                await _httpClient.PostAsync("/api/v1/contact-details", new StringContent(jsonRequestBody));
+            }
+        }
+
+        public class ContactDetailsPostRequest
+        {
+            public string NccContactId { get; set; }
+            public string Value { get; set; }
+            public bool Active { get; set; }
+            public bool Default { get; set; }
+            public int TypeId { get; set; }
+            public int SubtypeId { get; set; }
+        }
+
+        public class CommunicationDetails
+        {
+            public List<string> telephone { get; set; }
+            public List<string> mobile { get; set; }
+            public List<string> email { get; set; }
+            public DefaultContacts Default { get; set; }
+        }
+
+        public class DefaultContacts
+        {
+            public string telephone;
+            public string mobile;
+            public string email;
+        }
+    }
+}

--- a/LbhNCCApi/Controllers/CRMController.cs
+++ b/LbhNCCApi/Controllers/CRMController.cs
@@ -235,8 +235,15 @@ namespace LbhNCCApi.Controllers
         {
             try
             {
+                var contactDetailsApi = Environment.GetEnvironmentVariable("CONTACT_DETAILS_API_URL");
+                var contactDetailsClient = new HttpClient
+                {
+                    BaseAddress = new Uri(contactDetailsApi)
+                };
+                contactDetailsClient.DefaultRequestHeaders.Add("Authorization", Environment.GetEnvironmentVariable("CONTACT_DETAILS_API_TOKEN"));
+
                 HttpClient hclient = _client.GetCRMClient(false);
-                var result = new CRMActions().SetCitizenCommunication(contactid, CommObject, hclient).ToString();
+                var result = new CRMActions().SetCitizenCommunication(contactid, CommObject, hclient, contactDetailsClient).ToString();
                 return Ok(result);
             }
             catch (Exception ex)

--- a/LbhNCCApi/Exceptions/Helpers/CRMAPICall.cs
+++ b/LbhNCCApi/Exceptions/Helpers/CRMAPICall.cs
@@ -3,7 +3,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -108,7 +107,7 @@ namespace LbhNCCApi.Helpers
             return response;
         }
 
-        public static async Task<object> UpdateObject(HttpClient client, string requestUri, JObject updateObject)
+        public static async Task<Dictionary<string, Dictionary<string, object>>> UpdateObject(HttpClient client, string requestUri, JObject updateObject)
         {
             HttpResponseMessage updateResponse;
             var method = new HttpMethod("PATCH");

--- a/LbhNCCApi/Exceptions/Helpers/Validate.cs
+++ b/LbhNCCApi/Exceptions/Helpers/Validate.cs
@@ -23,9 +23,9 @@ namespace LbhNCCApi.Exceptions.Helpers
         }
 
 
-        public static object ReturnMessage(bool success, string message)
+        public static Dictionary<string, Dictionary<string, object>> ReturnMessage(bool success, string message)
         {
-            var errormessage = new Dictionary<string, object>
+            var errormessage = new Dictionary<string, Dictionary<string, object>>
                 {
                     {"response",
                             new Dictionary<string, object>{

--- a/LbhNCCApi/Interfaces/IContactDetailsApi.cs
+++ b/LbhNCCApi/Interfaces/IContactDetailsApi.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace LbhNCCApi.Interfaces
+{
+    public interface IContactDetailsApi
+    {
+        Task PostContactDetails(string contactId, string commsDetail);
+    }
+}

--- a/LbhNCCApi/LbhNCCApi.csproj
+++ b/LbhNCCApi/LbhNCCApi.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.0.0-preview" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/LbhNCCApi/Startup.cs
+++ b/LbhNCCApi/Startup.cs
@@ -1,7 +1,5 @@
-﻿using System.Configuration;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/LbhNCCApiTest/Controller/Actions/ContactDetailsApiTests.cs
+++ b/LbhNCCApiTest/Controller/Actions/ContactDetailsApiTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using LbhNCCApi.Actions;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace LbhNCCApiTest.Controller.Actions
+{
+    public class ContactDetailsApiTests
+    {
+        private Mock<HttpMessageHandler> _messageHandler;
+        private ContactDetailsApi _classUnderTest;
+
+        public ContactDetailsApiTests()
+        {
+            var uri = new Uri("http://test-domain-name.com/");
+            _messageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            Environment.SetEnvironmentVariable("CONTACT_DETAILS_API_TOKEN", "super secret token");
+
+            var httpClient = new HttpClient(_messageHandler.Object)
+            {
+                BaseAddress = uri,
+            };
+            _classUnderTest = new ContactDetailsApi(httpClient);
+        }
+
+        [Fact]
+        public void PostContactDetailsCanParseAndPostContactDetails()
+        {
+            var contactId = "CBWU-47983-CWHUGH-86";
+            var telephones = new List<string>{"02746284628"};
+            var mobiles = new List<string>{"02746554628"};
+            var emails = new List<string>{"hello@email.com"};
+            var commsDetails = SerializeToCommsDetailsString(telephones, mobiles, emails, telephones.First(), "1111111", emails.First());
+
+            var expectedPosts = new List<ContactDetailsApi.ContactDetailsPostRequest>
+            {
+                new ContactDetailsApi.ContactDetailsPostRequest
+                {
+                    Active = true,
+                    Default = true,
+                    Value = "02746284628",
+                    TypeId = 1,
+                    NccContactId = contactId
+                },
+                new ContactDetailsApi.ContactDetailsPostRequest
+                {
+                    Active = true,
+                    Default = false,
+                    Value = "02746554628",
+                    TypeId = 3,
+                    NccContactId = contactId
+                },
+                new ContactDetailsApi.ContactDetailsPostRequest
+                {
+                    Active = true,
+                    Default = true,
+                    Value = "hello@email.com",
+                    TypeId = 2, // TODO: find out what the correct values for these are
+                    NccContactId = contactId
+                }
+            };
+            expectedPosts.ForEach(post =>
+            {
+                var expectedBody = JsonConvert.SerializeObject(post);
+                SetUpMessageHandlerToReturnJson(_messageHandler, "/api/v1/contact-details", "POST", expectedBody);
+            });
+
+            _classUnderTest.PostContactDetails(contactId, commsDetails);
+            _messageHandler.Verify();
+        }
+
+        private static string SerializeToCommsDetailsString(List<string> telephones, List<string> mobiles, List<string> emails,
+            string defaultTelephone, string defaultMobile, string defaultEmail)
+        {
+            return
+                $"{{ telephone: [\"{string.Join("\", \"", telephones)}\"], mobile: [\"{string.Join("\", \"", mobiles)}\"]," +
+                $" email: [\"{string.Join("\", \"", emails)}\"], Default: {{ telephone: \"{defaultTelephone}\"," +
+                $" mobile: \"{defaultMobile}\", email: \"{defaultEmail}\" }}  }}";
+        }
+
+        private static void SetUpMessageHandlerToReturnJson(Mock<HttpMessageHandler> messageHandler, string endpoint, string method, string
+            expectedBody = null)
+        {
+            var stubbedResponse = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Created,
+            };
+
+            messageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => CheckRequest(req, endpoint, method, expectedBody)),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(stubbedResponse)
+                .Verifiable();
+        }
+
+        private static bool CheckRequest(HttpRequestMessage req, string endpoint, string method, string expectedBody)
+        {
+            return req.Method.ToString() == method
+                   && HttpUtility.UrlDecode(req.RequestUri.ToString()) == $"http://test-domain-name.com{endpoint}"
+                   && req.Content.ReadAsStringAsync().Result == expectedBody;
+        }
+    }
+}

--- a/LbhNCCApiTest/LbhNCCApiTest.csproj
+++ b/LbhNCCApiTest/LbhNCCApiTest.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
When setting communication details for a citizen we also want to post all of the communication details to the Contact Details API in order to keep that database up to date in parallel. 

This PR creates a class to call the contact details API and adds a method to parse the communication details string into individual contact details and then posts these individually to the API.

This method is then called after new communication details are successfully set.